### PR TITLE
Add specific version to collu in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 vdu-nlp-services>=0.0.26
-conllu
+conllu<3
 git+https://github.com/aleksas/multext-east-jablonskis-convertor.git


### PR DESCRIPTION
If `collu` is not installed, the newest version (in this case 3+) will be installed.
That breaks the code and constraining the version to `<3` solves the issue.